### PR TITLE
[TASK] Require PHP >= 5.5

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -30,7 +30,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'version' => '0.0.1',
 	'constraints' => array(
 		'depends' => array(
-			'php' => '5.3.7-5.5.999',
+			'php' => '5.5.0-7.0.999',
 			'typo3' => '6.0.0-6.3.999',
 			'typoscript_rendering' => '*',
 		),


### PR DESCRIPTION
PHP 5.3 and PHP 5.4 have reached their ends-of-life a long time ago.
