### PR TITLE
[TASK] 7.6 compatibility

### DIFF
--- a/Classes/Controller/ExampleController.php
+++ b/Classes/Controller/ExampleController.php
@@ -24,9 +24,8 @@ namespace Helhum\AjaxExample\Controller;
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
-use Helhum\AjaxExample\Property\TypeConverter\UploadedFileReferenceConverter;
+
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
-use TYPO3\CMS\Extbase\Property\PropertyMappingConfiguration;
 
 /**
  *

--- a/Classes/Core/EidRequestBootstrap.php
+++ b/Classes/Core/EidRequestBootstrap.php
@@ -63,10 +63,9 @@ class EidRequestBootstrap {
 		$typoScriptFrontendController->fe_user = $feUserObj;
 		$typoScriptFrontendController->id = $pageId;
 		$typoScriptFrontendController->determineId();
-		$typoScriptFrontendController->getCompressedTCarray();
 		$typoScriptFrontendController->initTemplate();
 		$typoScriptFrontendController->getConfigArray();
-		$typoScriptFrontendController->includeTCA();
+		EidUtility::initTCA();
 
 		/** @var TypoScriptService $typoScriptService */
 		$typoScriptService = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Service\\TypoScriptService');

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -31,7 +31,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'constraints' => array(
 		'depends' => array(
 			'php' => '5.3.7-7.0.999',
-			'typo3' => '6.0.0-6.3.999',
+			'typo3' => '6.2.0-7.6.999',
 			'typoscript_rendering' => '*',
 		),
 		'conflicts' => array(


### PR DESCRIPTION
With these changes, the extension runs fine in TYPO3 CMS 7.6.
- replace method calls that are deprecated in TYPO3 CMS 6.2
- set the allowed TYPO3 versions to 6.2.0-7.6.99
- drop two unused imports
