### PR TITLE
[BUGFIX] Use the current page for eID requests

### DIFF
--- a/Classes/Controller/ExampleController.php
+++ b/Classes/Controller/ExampleController.php
@@ -47,6 +47,7 @@ class ExampleController extends ActionController {
 	 * @return void
 	 */
 	public function indexAction() {
+		$this->view->assign('pageId', (int)$GLOBALS['TSFE']->id);
 	}
 
 	/**

--- a/Resources/Private/Templates/Example/Index.html
+++ b/Resources/Private/Templates/Example/Index.html
@@ -19,12 +19,12 @@
 	<h3>Different Ajax dispatch methods performance results:</h3>
 	<pre id="ajax-results"></pre>
 	<h4><f:link.action action="hello" format="json" pageType="{settings.ajaxPageType}" class="ajax-link">Ajax Request with Page Type</f:link.action> (not recommended)</h4>
-	<h4><a href="/index.php?eID=ajax_example&amp;tx_ajaxexample_piexample[format]=json" class="ajax-link">Ajax Request with eID</a> (not recommended)</h4>
+	<h4><a href="/index.php?id={pageId}&amp;eID=ajax_example&amp;tx_ajaxexample_piexample[format]=json" class="ajax-link">Ajax Request with eID</a> (not recommended)</h4>
 	<h4><a href="{t:uri.ajaxAction(action: 'hello', format: 'json', controller: 'Example', pluginName: 'PiExample') -> f:format.htmlentities()}" class="ajax-link">Ajax Request with TypoScript Rendering</a>  (recommended)</h4>
 
 	<h3>eID Performance compared with TS-Rendering:</h3>
-	<h4><a href="/index.php?eID=ajax_example_hello" class="ajax-link">Hello World by eID</a></h4>
-	<h4><a href="/index.php?eID=ajax_example_hello&amp;feuser=1" class="ajax-link">Hello World with feuser by eID</a></h4>
+	<h4><a href="/index.php?id={pageId}&amp;eID=ajax_example_hello" class="ajax-link">Hello World by eID</a></h4>
+	<h4><a href="/index.php?id={pageId}&amp;eID=ajax_example_hello&amp;feuser=1" class="ajax-link">Hello World with feuser by eID</a></h4>
 	<h4><f:link.page additionalParams="{tx_typoscriptrendering: {context: '{\"renderer\": \"hello\"}'}}" class="ajax-link">Hello World by TS-Rendering</f:link.page></h4>
 
 


### PR DESCRIPTION
The eID request URLs now always include the page UID of the current
front-end page instead of relying on the fallback UID of 1.

Using a UID of a fails if there is no page with this UID anymore
(or not for the current domain).
